### PR TITLE
Add benchmarks for llfio

### DIFF
--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -1,16 +1,20 @@
+include(${PROJECT_SOURCE_DIR}/cmake/fmt.cmake)
 include(${PROJECT_SOURCE_DIR}/cmake/catch2.cmake)
 include(${PROJECT_SOURCE_DIR}/cmake/celero.cmake)
 include(${PROJECT_SOURCE_DIR}/cmake/boost.cmake)
 include(${PROJECT_SOURCE_DIR}/cmake/benchmark.cmake)
 include(${PROJECT_SOURCE_DIR}/cmake/nanobench.cmake)
+include(${PROJECT_SOURCE_DIR}/cmake/llfio.cmake)
 
-set(COMMAND_SRC_FILES read_data)
+set(COMMAND_SRC_FILES read_data find_benchmark locate_benchmark)
 foreach(src_file ${COMMAND_SRC_FILES})
   add_executable(${src_file} ${src_file}.cpp)
   target_link_libraries(
     ${src_file}
+    fmt::fmt
     ioutils
     celero
+    llfio::hl
     Boost::system
     Boost::filesystem
     Boost::iostreams
@@ -18,15 +22,6 @@ foreach(src_file ${COMMAND_SRC_FILES})
     Catch2::Catch2WithMain)
   target_include_directories(${src_file} PRIVATE ${utils_SOURCE_DIR}/src)
 endforeach(src_file)
-
-set(COMMAND_BENCHMARK_COMMANDS find_benchmark locate_benchmark)
-foreach(BENCHMARK ${COMMAND_BENCHMARK_COMMANDS})
-  add_executable(${BENCHMARK} ${BENCHMARK}.cpp)
-  target_link_libraries(${BENCHMARK} PRIVATE celero Catch2::Catch2WithMain)
-  target_include_directories(
-    ${BENCHMARK} PRIVATE ${benchmark_SOURCE_DIR}/include/
-                         ${utils_SOURCE_DIR}/src)
-endforeach(BENCHMARK)
 
 set(COMMAND_BENCHMARK_COMMANDS filesystem_benchmark)
 foreach(BENCHMARK ${COMMAND_BENCHMARK_COMMANDS})

--- a/benchmark/find_benchmark.cpp
+++ b/benchmark/find_benchmark.cpp
@@ -1,7 +1,6 @@
 #include "celero/Celero.h"
 #include "nanobench.h"
 #include <catch2/catch_test_macros.hpp>
-#include <iostream>
 
 namespace {
     constexpr int number_of_samples = 10;

--- a/benchmark/read_data.cpp
+++ b/benchmark/read_data.cpp
@@ -1,18 +1,22 @@
 #include "catch2/catch_test_macros.hpp"
+#include "experiments.hpp"
+#include "fmt/base.h"
+#include "ioutils/read_policies.hpp"
 #include "ioutils/reader.hpp"
+#include "llfio/llfio.hpp"
 #include <boost/iostreams/device/mapped_file.hpp>
 #include <cstddef>
+#include <cstdlib>
 #include <fstream>
 #include <iostream>
 #include <string>
-#include "experiments.hpp"
-#include "ioutils/read_policies.hpp"
 
 #define ANKERL_NANOBENCH_IMPLEMENT
 #include <nanobench.h>
 
-namespace test {
+namespace {
     constexpr char EOL = '\n';
+
     template <typename Container> auto read_all_data_std_iostream(const std::string &afile) -> Container {
         std::ifstream t(afile);
         Container str;
@@ -27,7 +31,7 @@ namespace test {
     auto read_all_data_boost_iostreams(const std::string &afile) -> std::string {
         boost::iostreams::mapped_file mmap(afile, boost::iostreams::mapped_file::readonly);
         auto begin = mmap.const_data();
-        return std::string(begin, mmap.size());
+        return {begin, mmap.size()};
     }
 
     auto count_lines_using_std_iostream(const std::string &afile) -> size_t {
@@ -44,11 +48,68 @@ namespace test {
         boost::iostreams::mapped_file mmap(afile, boost::iostreams::mapped_file::readonly);
         auto begin = mmap.const_data();
         auto end = begin + mmap.size();
-        size_t lines;
-        std::for_each(begin, end, [&lines](auto const item) {
-            if (item == EOL) ++lines;
+        size_t counter;
+        std::for_each(begin, end, [&counter](auto const item) {
+            if (item == EOL) ++counter;
         });
-        return lines;
+        return counter;
+    }
+
+    auto read_all_data_llfio(const std::string &file_path) -> std::string {
+        namespace llfio = LLFIO_V2_NAMESPACE;
+        auto result = llfio::mapped_file({}, file_path, llfio::file_handle::mode::read,
+                                         llfio::file_handle::creation::open_existing,
+                                         llfio::file_handle::caching::all, llfio::file_handle::flag::none);
+        if (result.has_error()) {
+            fmt::print(stderr, "Cannot open: {}\n", file_path);
+            return {};
+        }
+        const auto &mh = result.value();
+        const auto len = mh.maximum_extent().value();
+        const char *begin = reinterpret_cast<char *>(mh.address());
+        const char *end = begin + len;
+        return {begin, end};
+    }
+
+    auto count_lines_llfio_memchr(const std::string &file_path) -> size_t {
+        namespace llfio = LLFIO_V2_NAMESPACE;
+        auto result = llfio::mapped_file({}, file_path, llfio::file_handle::mode::read,
+                                         llfio::file_handle::creation::open_existing,
+                                         llfio::file_handle::caching::all, llfio::file_handle::flag::none);
+        if (result.has_error()) {
+            fmt::print(stderr, "Cannot open: {}\n", file_path);
+            return EXIT_FAILURE;
+        }
+        const auto &mh = result.value();
+        const auto len = mh.maximum_extent().value();
+        const char *begin = reinterpret_cast<char *>(mh.address());
+        const char *end = begin + len;
+        size_t counter = 0;
+        while ((begin = static_cast<const char *>(memchr(begin, EOL, end - begin)))) {
+            ++counter;
+            ++begin;
+        }
+        return counter;
+    }
+
+    auto count_lines_llfio(const std::string &file_path) -> size_t {
+        namespace llfio = LLFIO_V2_NAMESPACE;
+        auto result = llfio::mapped_file({}, file_path, llfio::file_handle::mode::read,
+                                         llfio::file_handle::creation::open_existing,
+                                         llfio::file_handle::caching::all, llfio::file_handle::flag::none);
+        if (result.has_error()) {
+            fmt::print(stderr, "Cannot open: {}\n", file_path);
+            return EXIT_FAILURE;
+        }
+        const auto &mh = result.value();
+        const auto len = mh.maximum_extent().value();
+        const char *begin = reinterpret_cast<char *>(mh.address());
+        const char *end = begin + len;
+        size_t counter;
+        std::for_each(begin, end, [&counter](auto const item) {
+            if (item == EOL) ++counter;
+        });
+        return counter;
     }
 
     template <int chunk_size> decltype(auto) read_file_content_ioutils(const std::string &datafile) {
@@ -64,7 +125,7 @@ namespace test {
         reader(datafile.c_str());
         return reader;
     }
-} // namespace test
+} // namespace
 
 namespace {
     constexpr int number_of_samples = 20;
@@ -75,9 +136,10 @@ namespace {
 
 TEST_CASE("Benchmark different whole file content reading algorithms") {
     SECTION("Validate the correctness of all algorithms") {
-        const auto expected_results = test::read_all_data_std_iostream<std::string>(text_data_file);
-        CHECK(test::read_file_content_ioutils<16>(text_data_file).get_data() == expected_results);
-        CHECK(test::read_all_data_boost_iostreams(text_data_file) == expected_results);
+        const auto expected_results = read_all_data_std_iostream<std::string>(text_data_file);
+        CHECK(read_file_content_ioutils<16>(text_data_file).get_data() == expected_results);
+        CHECK(read_all_data_boost_iostreams(text_data_file) == expected_results);
+        CHECK(read_all_data_llfio(text_data_file) == expected_results);
     }
 
     auto bench = ankerl::nanobench::Bench()
@@ -85,51 +147,55 @@ TEST_CASE("Benchmark different whole file content reading algorithms") {
                      .minEpochIterations(minimum_number_of_operations);
 
     bench.run("iostream", []() {
-        ankerl::nanobench::doNotOptimizeAway(test::read_all_data_std_iostream<std::string>(text_data_file));
+        ankerl::nanobench::doNotOptimizeAway(read_all_data_std_iostream<std::string>(text_data_file));
     });
 
     bench.run("file_reader_chunksize=2^10", []() {
-        ankerl::nanobench::doNotOptimizeAway(test::read_file_content_ioutils<1 << 10>(text_data_file));
+        ankerl::nanobench::doNotOptimizeAway(read_file_content_ioutils<1 << 10>(text_data_file));
     });
 
     bench.run("file_reader_chunksize=2^11", []() {
-        ankerl::nanobench::doNotOptimizeAway(test::read_file_content_ioutils<1 << 11>(text_data_file));
+        ankerl::nanobench::doNotOptimizeAway(read_file_content_ioutils<1 << 11>(text_data_file));
     });
 
     bench.run("file_reader_chunksize=2^12", []() {
-        ankerl::nanobench::doNotOptimizeAway(test::read_file_content_ioutils<1 << 12>(text_data_file));
+        ankerl::nanobench::doNotOptimizeAway(read_file_content_ioutils<1 << 12>(text_data_file));
     });
 
     bench.run("file_reader_chunksize=2^13", []() {
-        ankerl::nanobench::doNotOptimizeAway(test::read_file_content_ioutils<1 << 13>(text_data_file));
+        ankerl::nanobench::doNotOptimizeAway(read_file_content_ioutils<1 << 13>(text_data_file));
     });
 
     bench.run("file_reader_chunksize=2^14", []() {
-        ankerl::nanobench::doNotOptimizeAway(test::read_file_content_ioutils<1 << 14>(text_data_file));
+        ankerl::nanobench::doNotOptimizeAway(read_file_content_ioutils<1 << 14>(text_data_file));
     });
 
     bench.run("file_reader_chunksize=2^15", []() {
-        ankerl::nanobench::doNotOptimizeAway(test::read_file_content_ioutils<1 << 15>(text_data_file));
+        ankerl::nanobench::doNotOptimizeAway(read_file_content_ioutils<1 << 15>(text_data_file));
     });
 
     bench.run("file_reader_chunksize=2^16", []() {
-        ankerl::nanobench::doNotOptimizeAway(test::read_file_content_ioutils<1 << 16>(text_data_file));
+        ankerl::nanobench::doNotOptimizeAway(read_file_content_ioutils<1 << 16>(text_data_file));
     });
 
     bench.run("file_reader_chunksize=2^17", []() {
-        ankerl::nanobench::doNotOptimizeAway(test::read_file_content_ioutils<1 << 17>(text_data_file));
+        ankerl::nanobench::doNotOptimizeAway(read_file_content_ioutils<1 << 17>(text_data_file));
     });
 
     bench.run("file_reader_chunksize=2^18", []() {
-        ankerl::nanobench::doNotOptimizeAway(test::read_file_content_ioutils<1 << 18>(text_data_file));
+        ankerl::nanobench::doNotOptimizeAway(read_file_content_ioutils<1 << 18>(text_data_file));
     });
 
     bench.run("file_reader_chunksize=2^19", []() {
-        ankerl::nanobench::doNotOptimizeAway(test::read_file_content_ioutils<1 << 19>(text_data_file));
+        ankerl::nanobench::doNotOptimizeAway(read_file_content_ioutils<1 << 19>(text_data_file));
     });
 
     bench.run("boost::iostream::mapped_file", []() {
-        ankerl::nanobench::doNotOptimizeAway(test::read_all_data_boost_iostreams(text_data_file));
+        ankerl::nanobench::doNotOptimizeAway(read_all_data_boost_iostreams(text_data_file));
+    });
+
+    bench.run("llfio::mapped_file", []() {
+        ankerl::nanobench::doNotOptimizeAway(read_all_data_llfio(text_data_file));
     });
 }
 
@@ -140,22 +206,29 @@ TEST_CASE("Benchmark different line counting algorithms") {
 
     SECTION("Validate the correctness of all algorithms") {
         const size_t expected_result = 302278;
-        CHECK(test::count_lines_using_std_iostream(text_data_file) == expected_result);
-        CHECK(test::count_lines_using_boost_iostreams(text_data_file) == expected_result);
-        CHECK(test::count_lines_using_ioutils<1 << 16>(text_data_file).get_count() == expected_result);
+        CHECK(count_lines_using_std_iostream(text_data_file) == expected_result);
+        CHECK(count_lines_using_boost_iostreams(text_data_file) == expected_result);
+        CHECK(count_lines_llfio(text_data_file) == expected_result);
+        CHECK(count_lines_using_ioutils<1 << 16>(text_data_file).get_count() == expected_result);
     }
 
     SECTION("Benchmark all line counting algorithms") {
 
         bench.run("Counting lines using std::iostream", []() {
-            ankerl::nanobench::doNotOptimizeAway(test::count_lines_using_std_iostream(text_data_file));
+            ankerl::nanobench::doNotOptimizeAway(count_lines_using_std_iostream(text_data_file));
         });
 
         bench.run("Counting lines using boost::iostreams", []() {
-            ankerl::nanobench::doNotOptimizeAway(test::count_lines_using_boost_iostreams(text_data_file));
+            ankerl::nanobench::doNotOptimizeAway(count_lines_using_boost_iostreams(text_data_file));
         });
 
+        bench.run("Counting lines using llfio",
+                  []() { ankerl::nanobench::doNotOptimizeAway(count_lines_llfio(text_data_file)); });
+
+        bench.run("Counting lines using llfio(memchr)",
+                  []() { ankerl::nanobench::doNotOptimizeAway(count_lines_llfio_memchr(text_data_file)); });
+
         bench.run("Counting lines using ioutils",
-                  []() { test::count_lines_using_ioutils<1 << 16>(text_data_file); });
+                  []() { count_lines_using_ioutils<1 << 16>(text_data_file); });
     }
 }

--- a/cmake/llfio.cmake
+++ b/cmake/llfio.cmake
@@ -1,0 +1,32 @@
+set(THIRDPARTY_DIR "${PROJECT_SOURCE_DIR}/3p/llfio")
+set(LLFIO_INSTALL_DIR ${THIRDPARTY_DIR})
+message("llfio path: ${LLFIO_INSTALL_DIR}")
+
+find_package(Threads REQUIRED)
+
+find_package(
+  quickcpplib
+  CONFIG
+  REQUIRED
+  NO_DEFAULT_PATH
+  PATHS
+  ${LLFIO_INSTALL_DIR}/lib/cmake
+  ${LLFIO_INSTALL_DIR}/lib64/cmake)
+
+find_package(
+  outcome
+  CONFIG
+  REQUIRED
+  NO_DEFAULT_PATH
+  PATHS
+  ${LLFIO_INSTALL_DIR}/lib/cmake
+  ${LLFIO_INSTALL_DIR}/lib64/cmake)
+
+find_package(
+  llfio
+  CONFIG
+  REQUIRED
+  NO_DEFAULT_PATH
+  PATHS
+  ${LLFIO_INSTALL_DIR}/lib/cmake
+  ${LLFIO_INSTALL_DIR}/lib64/cmake)


### PR DESCRIPTION
These are the benchmark results obtained using Linux (Linux hh 6.12.7-gentoo-hh #1 SMP PREEMPT_DYNAMIC Sun Dec 29 19:46:21 EST 2024 x86_64 AMD Ryzen 7 3700X 8-Core Processor AuthenticAMD GNU/Linux).

```text
Randomness seeded to: 3168082191

|               ns/op |                op/s |    err% |          ins/op |          cyc/op |    IPC |         bra/op |   miss% |     total | benchmark
|--------------------:|--------------------:|--------:|----------------:|----------------:|-------:|---------------:|--------:|----------:|:----------
|       66,297,378.33 |               15.08 |    1.4% |  675,700,147.33 |  213,722,594.67 |  3.162 | 112,334,176.67 |    0.0% |      2.23 | `iostream`
|       11,846,301.75 |               84.41 |    0.3% |    4,298,965.00 |    8,862,389.67 |  0.485 |     633,464.00 |    5.3% |      0.40 | `file_reader_chunksize=2^10`
|        7,634,967.67 |              130.98 |    0.7% |    3,692,822.00 |    9,175,637.33 |  0.402 |     445,746.33 |    3.5% |      0.26 | `file_reader_chunksize=2^11`
|        5,402,409.67 |              185.10 |    0.2% |    3,387,014.75 |    8,687,123.67 |  0.390 |     351,750.67 |    2.2% |      0.18 | `file_reader_chunksize=2^12`
|        4,552,996.25 |              219.64 |    0.2% |    3,233,514.00 |    8,636,551.67 |  0.374 |     304,653.67 |    1.3% |      0.16 | `file_reader_chunksize=2^13`
|        4,244,647.33 |              235.59 |    0.2% |    3,153,954.67 |    9,152,156.67 |  0.345 |     281,001.00 |    1.1% |      0.14 | `file_reader_chunksize=2^14`
|        4,051,642.33 |              246.81 |    0.5% |    3,115,621.25 |    9,203,772.67 |  0.339 |     269,005.67 |    0.6% |      0.14 | `file_reader_chunksize=2^15`
|        3,943,168.00 |              253.60 |    0.4% |    3,092,940.67 |    9,238,495.67 |  0.335 |     262,766.33 |    0.3% |      0.13 | `file_reader_chunksize=2^16`
|        3,844,514.00 |              260.11 |    0.3% |    3,076,683.00 |    9,096,769.00 |  0.338 |     259,201.33 |    0.2% |      0.13 | `file_reader_chunksize=2^17`
|        3,832,910.33 |              260.90 |    0.1% |    3,059,108.00 |    9,111,052.67 |  0.336 |     256,604.33 |    0.1% |      0.13 | `file_reader_chunksize=2^18`
|        3,817,960.33 |              261.92 |    0.2% |    3,031,693.33 |    9,213,402.00 |  0.329 |     253,736.67 |    0.0% |      0.13 | `file_reader_chunksize=2^19`
|        1,501,351.75 |              666.07 |    0.4% |    1,763,584.67 |    3,158,056.67 |  0.558 |      65,158.00 |    0.4% |      0.05 | `boost::iostream::mapped_file`
|        1,498,131.67 |              667.50 |    0.4% |    1,764,655.25 |    3,158,043.33 |  0.559 |      65,312.67 |    0.4% |      0.05 | `llfio::mapped_file`
|       13,757,322.67 |               72.69 |    0.2% |  256,480,229.33 |   48,512,183.33 |  5.287 |  48,106,999.00 |    0.0% |      0.47 | `Counting lines using std::iostream`
|        2,449,686.00 |              408.22 |    0.6% |   23,021,821.00 |    7,157,415.67 |  3.216 |   1,001,404.75 |    0.0% |      0.08 | `Counting lines using boost::iostreams`
|        2,497,343.00 |              400.43 |    0.5% |   23,022,913.33 |    7,341,031.33 |  3.136 |   1,001,563.33 |    0.0% |      0.09 | `Counting lines using llfio`
|        3,148,005.00 |              317.66 |    0.2% |   12,588,989.33 |   10,092,564.00 |  1.247 |   3,124,549.67 |    3.7% |      0.11 | `Counting lines using llfio(memchr)`
|        3,574,528.33 |              279.76 |    0.1% |   12,903,876.00 |    9,803,591.00 |  1.316 |   3,128,930.67 |    3.7% |      0.12 | `Counting lines using ioutils`
===============================================================================
All tests passed (7 assertions in 2 test cases)
```