### PR TITLE
Enable LTO by default

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 _deps
-venv
 3p
+.local

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,6 +51,7 @@ endif()
 
 # Get required libraries
 include(FetchContent)
+include(cmake/lto.cmake)
 include(cmake/hyperscan.cmake)
 include(cmake/fmt.cmake)
 include(cmake/utils.cmake)
@@ -59,6 +60,7 @@ include(cmake/clara.cmake)
 include(cmake/format_files.cmake)
 include(cmake/jemalloc.cmake)
 include(cmake/nanobench.cmake)
+include(cmake/reflex.cmake)
 
 set(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/_deps/cmake_scripts-src/;")
 include(c++-standards)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,3 +1,5 @@
+cmake_minimum_required(VERSION 3.25)
+
 cmake_policy(SET CMP0048 NEW)
 project(
   ioutils
@@ -5,7 +7,6 @@ project(
   DESCRIPTION "A blazing fast replacement tools for find and locate commands."
   LANGUAGES CXX)
 
-cmake_minimum_required(VERSION 3.15)
 
 # Use ccache by default
 find_program(CCACHE_PROGRAM ccache)

--- a/cmake/fmt.cmake
+++ b/cmake/fmt.cmake
@@ -5,6 +5,6 @@ set(FMT_TEST OFF)
 FetchContent_Declare(
   fmt
   GIT_REPOSITORY git@github.com:fmtlib/fmt.git
-  GIT_TAG 11.0.2
+  GIT_TAG 11.1.4
   GIT_SHALLOW TRUE)
 FetchContent_MakeAvailable(fmt)

--- a/cmake/lto.cmake
+++ b/cmake/lto.cmake
@@ -1,0 +1,7 @@
+# Use LLVM toolchain by default
+if(CMAKE_BUILD_TYPE MATCHES "Release")
+  set(CMAKE_LINKER_TYPE LLD)
+  set(CMAKE_INTERPROCEDURAL_OPTIMIZATION TRUE)
+else()
+  message("Disable TLO for non-release builds")
+endif()

--- a/cmake/reflex.cmake
+++ b/cmake/reflex.cmake
@@ -1,0 +1,9 @@
+include(FetchContent)
+
+FetchContent_Declare(
+  reflex
+  GIT_REPOSITORY git@github.com:hungptit/RE-flex.git
+  GIT_TAG master
+  GIT_SHALLOW TRUE)
+
+FetchContent_MakeAvailable(reflex)

--- a/cmake/shell-check.cmake
+++ b/cmake/shell-check.cmake
@@ -1,4 +1,4 @@
-file(GLOB SRC 3p/build*.sh *.sh)
+file(GLOB SRC scripts/build*.sh *.sh)
 find_program(SHELLCHECK NAMES shellcheck)
 if(SHELLCHECK)
   add_custom_target(check COMMAND ${SHELLCHECK} ${SRC})

--- a/commands/CMakeLists.txt
+++ b/commands/CMakeLists.txt
@@ -1,5 +1,3 @@
-set(CMAKE_INTERPROCEDURAL_OPTIMIZATION ON)
-
 set(COMMANDS fast-updatedb fast-locate fast-find fast-wc)
 foreach(COMMAND ${COMMANDS})
   add_executable(${COMMAND} ${COMMAND}.cpp)

--- a/scripts/build_using_cmake.sh
+++ b/scripts/build_using_cmake.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+set -euo pipefail # Use Bash strict mode
+
+os=$(uname)
+case "$os" in
+  "Darwin")
+    {
+      number_of_cpus=$(sysctl -n hw.ncpu)
+    }
+    ;;
+  "Linux")
+    {
+      number_of_cpus=$(grep -c ^processor /proc/cpuinfo)
+    }
+    ;;
+  *)
+    {
+      echo "Unsupported OS, exiting"
+      exit
+    }
+    ;;
+esac
+
+pkgname="$1"
+root_dir="$PWD"
+local_dir="$root_dir/.local"
+src_dir="$root_dir/_deps/$pkgname-src"
+prefix_dir="$root_dir/3p/$pkgname"
+
+build_dir="$local_dir/build"
+rm -rf "$build_dir"
+mkdir -p "$build_dir"
+
+pushd "$build_dir"
+cmake "$src_dir" -DCMAKE_INSTALL_PREFIX="$prefix_dir" -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_CXX_STANDARD=20 "${@:2}"
+make "-j$number_of_cpus"
+make install
+
+# Return to the original folder.
+popd


### PR DESCRIPTION
* Enable LTO for release builds.
* Add CMake definitions for RE-flex.
* Clean up CMake warnings and formatting files. 